### PR TITLE
Delete the wrong requirement

### DIFF
--- a/core/util.py
+++ b/core/util.py
@@ -28,9 +28,8 @@ def swipe(org: (int, int), tar: (int, int), delay):
 
 
 def screenshot() -> str:
-    # os.system('adb shell screencap -p /sdcard/sh.png')
-    # os.system('adb pull /sdcard/sh.png .')
-    os.system('adb exec-out screencap -p > sh.png')
+    os.system('adb shell screencap -p /sdcard/sh.png')
+    os.system('adb pull /sdcard/sh.png .')
     return "sh.png"
 
 
@@ -52,7 +51,7 @@ def get_sh(edge: (int, int)) -> str:
 
 
 # OpenCV related
-def standby(sh: str, tmp: str, threshold: float = 0.9) -> bool:
+def standby(sh: str, tmp: str, threshold: float = 0.8) -> bool:
     img = cv2.imread(sh, 0)
     template = cv2.imread(tmp, 0)
     res = cv2.matchTemplate(img, template, cv2.TM_CCOEFF_NORMED)
@@ -61,7 +60,7 @@ def standby(sh: str, tmp: str, threshold: float = 0.9) -> bool:
     return False
 
 
-def get_crd(sh: str, tmp: str, threshold: float = 0.9) -> [(int, int)]:
+def get_crd(sh: str, tmp: str, threshold: float = 0.8) -> [(int, int)]:
     img = cv2.imread(sh, 0)
     template = cv2.imread(tmp, 0)
     res = cv2.matchTemplate(img, template, cv2.TM_CCOEFF_NORMED)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,3 @@
 numpy==1.18.0
 opencv-python==4.1.2.30
 Pillow==6.2.1
-pkg-resources==0.0.0


### PR DESCRIPTION
sorry to change the way to get a screenshot, I have changed it back.I think your way is better,I don't know why the other way is slower. 
I don't know why `pip freeze > requirements.txt` add a wrong requirement,which may cause a bug when someone try to run`pip -r requirements.txt`.so I delete the wrong requirement.
by the way,if `threshold` is `0.9`,  that can't match the picture of my phone, so I have change it in to 0.8.